### PR TITLE
feature/serialization-improve-performance

### DIFF
--- a/src/flatcollections-array/FlatArray/FlatArray.T.JsonConverter/FlatArray.JsonConverter.InnerJsonExceptionFactory.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.JsonConverter/FlatArray.JsonConverter.InnerJsonExceptionFactory.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace System;
+
+partial struct FlatArray<T>
+{
+    partial class JsonConverter
+    {
+        private static class InnerJsonExceptionFactory
+        {
+            internal static JsonException JsonTokenNotStartArray()
+                =>
+                new("The last processed JSON token is not the start of a JSON array.");
+
+            internal static JsonException JsonReadCompletedNoEndArray()
+                =>
+                new("Reading the JSON completed, but the end of the JSON array was not found.");
+        }
+    }
+}

--- a/src/flatcollections-array/FlatArray/FlatArray.T.JsonConverter/FlatArray.JsonConverter.Read.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.JsonConverter/FlatArray.JsonConverter.Read.cs
@@ -19,12 +19,12 @@ partial struct FlatArray<T>
 
             if (reader.TokenType is not JsonTokenType.StartArray)
             {
-                throw InnerExceptionFactory.JsonTokenNotStartArray();
+                throw InnerJsonExceptionFactory.JsonTokenNotStartArray();
             }
 
             if (reader.Read() is not true)
             {
-                throw InnerExceptionFactory.JsonReadCompletedNoEndArray();
+                throw InnerJsonExceptionFactory.JsonReadCompletedNoEndArray();
             }
 
             if (reader.TokenType is JsonTokenType.EndArray)
@@ -58,7 +58,7 @@ partial struct FlatArray<T>
 
                 if (reader.Read() is not true)
                 {
-                    throw InnerExceptionFactory.JsonReadCompletedNoEndArray();
+                    throw InnerJsonExceptionFactory.JsonReadCompletedNoEndArray();
                 }
             }
             while (reader.TokenType is not JsonTokenType.EndArray);

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerExceptionFactory/FlatArray.InnerExceptionFactory.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerExceptionFactory/FlatArray.InnerExceptionFactory.cs
@@ -1,4 +1,5 @@
-﻿using static System.FormattableString;
+﻿using System.Text.Json;
+using static System.FormattableString;
 
 namespace System;
 
@@ -33,5 +34,13 @@ partial struct FlatArray<T>
         internal static NotSupportedException NotSupportedOnReadOnlyArray()
             =>
             new("The operation is not supported on read-only array.");
+
+        internal static JsonException JsonTokenNotStartArray()
+            =>
+            new("The last processed JSON token is not the start of a JSON array.");
+
+        internal static JsonException JsonReadCompletedNoEndArray()
+            =>
+            new("Reading the JSON completed, but the end of the JSON array was not found.");
     }
 }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerExceptionFactory/FlatArray.InnerExceptionFactory.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerExceptionFactory/FlatArray.InnerExceptionFactory.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using static System.FormattableString;
+﻿using static System.FormattableString;
 
 namespace System;
 
@@ -34,13 +33,5 @@ partial struct FlatArray<T>
         internal static NotSupportedException NotSupportedOnReadOnlyArray()
             =>
             new("The operation is not supported on read-only array.");
-
-        internal static JsonException JsonTokenNotStartArray()
-            =>
-            new("The last processed JSON token is not the start of a JSON array.");
-
-        internal static JsonException JsonReadCompletedNoEndArray()
-            =>
-            new("Reading the JSON completed, but the end of the JSON array was not found.");
     }
 }


### PR DESCRIPTION
`FlatArray<T>.JsonConverter`:
- Improve deserialization performance (avoid read buffer allocation for the empty array case)
- Improve deserialization readability