### PR TITLE
release/v1.2.0-rc.2

### DIFF
--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.Array.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.Array.cs
@@ -25,7 +25,7 @@ partial struct FlatArray<T>
         {
             var itemsLength = items?.Length ?? default;
 
-            if (InnerAllocHelper.IsWithin(length, itemsLength) is not true)
+            if (InnerAllocHelper.IsWithinLength(length, itemsLength) is not true)
             {
                 throw InnerExceptionFactory.StartSegmentIsNotWithinArray(nameof(length), length, itemsLength);
             }

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.FlatArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.FlatArray.cs
@@ -31,7 +31,7 @@ partial struct FlatArray<T>
         private Builder InnerAddRangeChecked(
             FlatArray<T> items, int length, [CallerArgumentExpression(nameof(length))] string lengthParamName = "")
         {
-            if (InnerAllocHelper.IsWithin(length, items.length) is not true)
+            if (InnerAllocHelper.IsWithinLength(length, items.length) is not true)
             {
                 throw InnerExceptionFactory.StartSegmentIsNotWithinArray(lengthParamName, length, items.length);
             }

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.ImmutableArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.ImmutableArray.cs
@@ -35,7 +35,7 @@ partial struct FlatArray<T>
         {
             var itemsLength = items.IsDefault ? default : items.Length;
 
-            if (InnerAllocHelper.IsWithin(length, itemsLength) is not true)
+            if (InnerAllocHelper.IsWithinLength(length, itemsLength) is not true)
             {
                 throw InnerExceptionFactory.StartSegmentIsNotWithinArray(lengthParamName, length, itemsLength);
             }

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.List.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.List.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+partial struct FlatArray<T>
+{
+    partial class Builder
+    {
+        // TODO: Add the tests and make public
+        internal Builder AddRange([AllowNull] List<T> items)
+        {
+            if (items is null || items.Count == default)
+            {
+                return this;
+            }
+
+            InnerAddRange(items, items.Count);
+            return this;
+        }
+
+        // TODO: Add the tests and make public
+        internal Builder AddRange([AllowNull] List<T> items, int length)
+        {
+            var itemsLength = items?.Count ?? default;
+
+            if (InnerAllocHelper.IsWithinLength(length, itemsLength) is not true)
+            {
+                throw InnerExceptionFactory.StartSegmentIsNotWithinArray(nameof(length), length, itemsLength);
+            }
+
+            if (items is null || items.Count == default)
+            {
+                return this;
+            }
+
+            InnerAddRange(items, length);
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void InnerAddRange(List<T> items, int length)
+        {
+            Debug.Assert(items.Count != default);
+            Debug.Assert(length > 0 && length <= items.Count);
+
+            InnerBufferHelperEx.EnsureBufferCapacity(ref this.items, this.length, length);
+            items.CopyTo(0, this.items, this.length, length);
+            this.length += length;
+        }
+    }
+}

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.Capacity.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.Capacity.cs
@@ -11,7 +11,7 @@ partial struct FlatArray<T>
 
             set
             {
-                if (InnerAllocHelper.IsWithin(length, value) is not true)
+                if (value >= length is not true)
                 {
                     throw InnerBuilderExceptionFactory.CapacityOutOfRange_MustBeGreaterThanOrEqualToLength(value, length);
                 }

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/InnerBufferHelper/FlatArray.Builder.InnerBufferHelperEx.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/InnerBufferHelper/FlatArray.Builder.InnerBufferHelperEx.cs
@@ -9,7 +9,6 @@ partial struct FlatArray<T>
     {
         private static class InnerBufferHelperEx
         {
-            // The caller MUST ensure the length and the length increase are GREATER than zero
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal static void EnsureBufferCapacity(
                 ref T[] array,

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/InnerBufferHelper/FlatArray.Builder.InnerBufferHelperEx.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/InnerBufferHelper/FlatArray.Builder.InnerBufferHelperEx.cs
@@ -20,8 +20,8 @@ partial struct FlatArray<T>
                 Debug.Assert(lengthIncrease >= 0);
 
                 int newLength = unchecked(length + lengthIncrease);
-                int doubleLength = length << 1; // unchecked(length * 2);
-                int newCapacity = unchecked((uint)newLength) > unchecked((uint)doubleLength)
+                int doubleLength = InnerAllocHelper.DoubleUnchecked(length);
+                int newCapacity = InnerAllocHelper.IsWithinCapacity(doubleLength, newLength)
                     ? newLength
                     : doubleLength;
 

--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/InnerBufferHelper/FlatArray.Builder.InnerBufferHelperEx.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/InnerBufferHelper/FlatArray.Builder.InnerBufferHelperEx.cs
@@ -20,7 +20,7 @@ partial struct FlatArray<T>
 
                 int newLength = unchecked(length + lengthIncrease);
                 int doubleLength = InnerAllocHelper.DoubleUnchecked(length);
-                int newCapacity = InnerAllocHelper.IsWithinCapacity(doubleLength, newLength)
+                int newCapacity = InnerAllocHelper.IsWithinCapacityUnchecked(doubleLength, newLength)
                     ? newLength
                     : doubleLength;
 

--- a/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.Array.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.Array.cs
@@ -17,7 +17,7 @@ partial struct FlatArray<T>
     {
         var sourceLength = source?.Length ?? default;
 
-        if (InnerAllocHelper.IsSegmentWithin(start, length, sourceLength) is not true)
+        if (InnerAllocHelper.IsSegmentWithinLength(start, length, sourceLength) is not true)
         {
             throw InnerExceptionFactory.SegmentIsNotWithinArray(start, length, sourceLength);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.FlatArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.FlatArray.cs
@@ -22,7 +22,7 @@ partial struct FlatArray<T>
 
     internal static FlatArray<T> InternalFromFlatArrayChecked(FlatArray<T> source, int start, int length)
     {
-        if (InnerAllocHelper.IsSegmentWithin(start, length, source.length) is not true)
+        if (InnerAllocHelper.IsSegmentWithinLength(start, length, source.length) is not true)
         {
             throw InnerExceptionFactory.SegmentIsNotWithinArray(start, length, source.length);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.ImmutableArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.ImmutableArray.cs
@@ -26,7 +26,7 @@ partial struct FlatArray<T>
     {
         var sourceLength = source.IsDefault ? default : source.Length;
 
-        if (InnerAllocHelper.IsSegmentWithin(start, length, sourceLength) is not true)
+        if (InnerAllocHelper.IsSegmentWithinLength(start, length, sourceLength) is not true)
         {
             throw InnerExceptionFactory.SegmentIsNotWithinArray(start, length, sourceLength);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.List.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/FlatArray.Factory.Explicit.From.List.cs
@@ -18,7 +18,7 @@ partial struct FlatArray<T>
     {
         var sourceLength = source?.Count ?? default;
 
-        if (InnerAllocHelper.IsSegmentWithin(start, length, sourceLength) is not true)
+        if (InnerAllocHelper.IsSegmentWithinLength(start, length, sourceLength) is not true)
         {
             throw InnerExceptionFactory.SegmentIsNotWithinArray(start, length, sourceLength);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerAllocHelper/FlatArray.InnerAllocHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerAllocHelper/FlatArray.InnerAllocHelper.cs
@@ -9,7 +9,6 @@ partial struct FlatArray<T>
     {
         internal const int DefaultPositiveCapacity = 4;
 
-        // The caller MUST ensure the length is GREATER than or EQUAL to zero
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsIndexInRange(int index, int length)
         {
@@ -19,19 +18,36 @@ partial struct FlatArray<T>
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsWithin(int value, int threshold)
-            =>
-            unchecked((uint)value) <= unchecked((uint)threshold);
+        internal static bool IsWithinLength(int value, int length)
+        {
+            Debug.Assert(value >= 0);
+            Debug.Assert(length >= 0);
+
+            return IsWithin(value, length);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsSegmentWithin(int start, int length, int threshold)
+        internal static bool IsSegmentWithinLength(int segmentStart, int segmentLength, int length)
+        {
+            Debug.Assert(segmentStart >= 0);
+            Debug.Assert(segmentLength >= 0);
+            Debug.Assert(length >= 0);
+
+            return (ulong)unchecked((uint)segmentStart) + unchecked((uint)segmentLength) <= unchecked((uint)length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsWithinCapacity(int value, int capacity)
             =>
-            (ulong)unchecked((uint)start) + unchecked((uint)length) <= unchecked((uint)threshold);
+            IsWithin(value, capacity);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int EnsurePositiveCapacity(int capacity)
-            =>
-            capacity > 0 ? capacity : DefaultPositiveCapacity;
+        {
+            Debug.Assert(capacity >= 0);
+
+            return capacity > 0 ? capacity : DefaultPositiveCapacity;
+        }
 
         // The caller MUST ensure the capacity is GREATER than or EQUAL to zero
         internal static int EnsureCapacityWithinDefaultPositive(int capacity)
@@ -47,7 +63,7 @@ partial struct FlatArray<T>
         {
             Debug.Assert(capacity > 0 && capacity < maxCapacity);
 
-            int newCapacity = InnerDoubleUnchecked(capacity);
+            int newCapacity = DoubleUnchecked(capacity);
             return IsWithin(newCapacity, maxCapacity) ? newCapacity : maxCapacity;
         }
 
@@ -62,13 +78,18 @@ partial struct FlatArray<T>
                 return false;
             }
 
-            int doubleLength = InnerDoubleUnchecked(length);
+            int doubleLength = DoubleUnchecked(length);
             return IsWithin(doubleLength, capacity);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int InnerDoubleUnchecked(int value)
+        internal static int DoubleUnchecked(int value)
             =>
             value << 1; // unchecked(value * 2);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsWithin(int value, int threshold)
+            =>
+            unchecked((uint)value) <= unchecked((uint)threshold);
     }
 }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerAllocHelper/FlatArray.InnerAllocHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerAllocHelper/FlatArray.InnerAllocHelper.cs
@@ -49,7 +49,6 @@ partial struct FlatArray<T>
             return capacity > 0 ? capacity : DefaultPositiveCapacity;
         }
 
-        // The caller MUST ensure the capacity is GREATER than or EQUAL to zero
         internal static int EnsureCapacityWithinDefaultPositive(int capacity)
         {
             Debug.Assert(capacity >= 0);
@@ -57,7 +56,6 @@ partial struct FlatArray<T>
             return IsWithin(capacity, DefaultPositiveCapacity) ? capacity : DefaultPositiveCapacity;
         }
 
-        // The caller MUST ensure the capacity is GREATER than zero and LESS than the max capacity
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int EnlargeCapacity(int capacity, int maxCapacity)
         {
@@ -67,7 +65,6 @@ partial struct FlatArray<T>
             return IsWithin(newCapacity, maxCapacity) ? newCapacity : maxCapacity;
         }
 
-        // The caller MUST ensure the length is GREATER than zero and LESS than or EQUAL to the capacity
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsHugeCapacity(int length, int capacity)
         {

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerAllocHelper/FlatArray.InnerAllocHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerAllocHelper/FlatArray.InnerAllocHelper.cs
@@ -23,7 +23,7 @@ partial struct FlatArray<T>
             Debug.Assert(value >= 0);
             Debug.Assert(length >= 0);
 
-            return IsWithin(value, length);
+            return InnerIsWithinUnchecked(value, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -37,9 +37,9 @@ partial struct FlatArray<T>
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsWithinCapacity(int value, int capacity)
+        internal static bool IsWithinCapacityUnchecked(int value, int capacity)
             =>
-            IsWithin(value, capacity);
+            InnerIsWithinUnchecked(value, capacity);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int EnsurePositiveCapacity(int capacity)
@@ -53,7 +53,7 @@ partial struct FlatArray<T>
         {
             Debug.Assert(capacity >= 0);
 
-            return IsWithin(capacity, DefaultPositiveCapacity) ? capacity : DefaultPositiveCapacity;
+            return InnerIsWithinUnchecked(capacity, DefaultPositiveCapacity) ? capacity : DefaultPositiveCapacity;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -62,7 +62,7 @@ partial struct FlatArray<T>
             Debug.Assert(capacity > 0 && capacity < maxCapacity);
 
             int newCapacity = DoubleUnchecked(capacity);
-            return IsWithin(newCapacity, maxCapacity) ? newCapacity : maxCapacity;
+            return InnerIsWithinUnchecked(newCapacity, maxCapacity) ? newCapacity : maxCapacity;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -70,13 +70,13 @@ partial struct FlatArray<T>
         {
             Debug.Assert(length > 0 && length <= capacity);
 
-            if (IsWithin(capacity, DefaultPositiveCapacity))
+            if (InnerIsWithinUnchecked(capacity, DefaultPositiveCapacity))
             {
                 return false;
             }
 
             int doubleLength = DoubleUnchecked(length);
-            return IsWithin(doubleLength, capacity);
+            return InnerIsWithinUnchecked(doubleLength, capacity);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -85,7 +85,7 @@ partial struct FlatArray<T>
             value << 1; // unchecked(value * 2);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsWithin(int value, int threshold)
+        private static bool InnerIsWithinUnchecked(int value, int threshold)
             =>
             unchecked((uint)value) <= unchecked((uint)threshold);
     }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
@@ -28,7 +28,7 @@ partial struct FlatArray<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T[] CopySegment(T[] array, int start, int length)
         {
-            Debug.Assert(InnerAllocHelper.IsSegmentWithin(start, length, array.Length));
+            Debug.Assert(InnerAllocHelper.IsSegmentWithinLength(start, length, array.Length));
 
             var sourceSpan = start == default && length == array.Length
                 ? new ReadOnlySpan<T>(array)

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
@@ -12,7 +12,6 @@ partial struct FlatArray<T>
             =>
             new ReadOnlySpan<T>(array).ToArray();
 
-        // The caller MUST ensure the length is within the array length
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T[] Copy(T[] array, int length)
         {
@@ -24,7 +23,6 @@ partial struct FlatArray<T>
             return sourceSpan.ToArray();
         }
 
-        // The caller MUST ensure the segment is within the array
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T[] CopySegment(T[] array, int start, int length)
         {
@@ -36,7 +34,6 @@ partial struct FlatArray<T>
             return sourceSpan.ToArray();
         }
 
-        // The caller MUST ensure the lengths are within the arrays actual lengths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T[] Concat(T[] array1, int length1, T[] array2, int length2)
         {

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromArray.cs
@@ -15,7 +15,7 @@ partial struct FlatArray<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static FlatArray<T> FromArray(T[] source, int start, int length)
         {
-            Debug.Assert(InnerAllocHelper.IsSegmentWithin(start, length, source.Length));
+            Debug.Assert(InnerAllocHelper.IsSegmentWithinLength(start, length, source.Length));
 
             return length == default ? default : new(InnerArrayHelper.CopySegment(source, start, length), default);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromFlatArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromFlatArray.cs
@@ -15,7 +15,7 @@ partial struct FlatArray<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static FlatArray<T> FromFlatArray(FlatArray<T> source, int start, int length)
         {
-            Debug.Assert(InnerAllocHelper.IsSegmentWithin(start, length, source.length));
+            Debug.Assert(InnerAllocHelper.IsSegmentWithinLength(start, length, source.length));
 
             return length == default ? default : new(InnerArrayHelper.CopySegment(source.items!, start, length), default);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromImmutableArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromImmutableArray.cs
@@ -27,7 +27,7 @@ partial struct FlatArray<T>
         {
             Debug.Assert(InnerAllocHelper.IsSegmentWithin(start, length, source.IsDefault ? default : source.Length));
 
-            if (source.IsDefaultOrEmpty)
+            if (length == default)
             {
                 return default;
             }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromImmutableArray.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromImmutableArray.cs
@@ -25,7 +25,7 @@ partial struct FlatArray<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static FlatArray<T> FromImmutableArray(ImmutableArray<T> source, int start, int length)
         {
-            Debug.Assert(InnerAllocHelper.IsSegmentWithin(start, length, source.IsDefault ? default : source.Length));
+            Debug.Assert(InnerAllocHelper.IsSegmentWithinLength(start, length, source.IsDefault ? default : source.Length));
 
             if (length == default)
             {

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromList.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerFactory/FlatArray.InnerFactory.FromList.cs
@@ -26,7 +26,7 @@ partial struct FlatArray<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static FlatArray<T> FromList(List<T> source, int start, int length)
         {
-            Debug.Assert(InnerAllocHelper.IsSegmentWithin(start, length, source.Count));
+            Debug.Assert(InnerAllocHelper.IsSegmentWithinLength(start, length, source.Count));
 
             if (length == default)
             {

--- a/src/flatcollections-array/FlatArray/FlatArray.csproj
+++ b/src/flatcollections-array/FlatArray/FlatArray.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Core.FlatArray is a core library for .NET consisting of immutable FlatArray targeted for use in functional programming.</Description>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>PrimeFuncPack.Core.FlatArray</AssemblyName>
-    <Version>1.2.0-rc.1</Version>
+    <Version>1.2.0-rc.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/flatcollections/FlatCollections/FlatCollections.csproj
+++ b/src/flatcollections/FlatCollections/FlatCollections.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Core.FlatCollections is a set of immutable Flat collections for .NET designed for developing business applications based on functional programming.</Description>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>PrimeFuncPack.Core.FlatCollections</AssemblyName>
-    <Version>1.2.0-rc.1</Version>
+    <Version>1.2.0-rc.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrimeFuncPack.Core.FlatArray" Version="1.2.0-rc.1" />
+    <PackageReference Include="PrimeFuncPack.Core.FlatArray" Version="1.2.0-rc.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`FlatArray`:
- Fix `Builder.Capacity` (currently non-public)
- Fix segment-based `FlatArray.InnerFactory.FromImmutableArray` (currently of non-public `From(ImmutableArray<T>)`)
- `Builder`: add `List`-based `AddRange` (currently non-public)
- Minor improvements/refactor
- Remove some redundant comments that duplicate `Debug.Assert` statements
- release/v1.2.0-rc.2