### PR TITLE
feature/minor-refactor

### DIFF
--- a/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.Array.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.Builder/FlatArray.Builder.AddRange.Array.cs
@@ -46,10 +46,13 @@ partial struct FlatArray<T>
             Debug.Assert(length > 0 && length <= items.Length);
 
             InnerBuilderBufferHelper.EnsureBufferCapacity(ref this.items, this.length, length);
-            var sourceSpan = length == items.Length
-                ? new ReadOnlySpan<T>(items)
-                : new ReadOnlySpan<T>(items, 0, length);
+
+            ReadOnlySpan<T> sourceSpan = length == items.Length
+                ? new(items)
+                : new(items, 0, length);
+
             sourceSpan.CopyTo(new Span<T>(this.items, this.length, length));
+
             this.length += length;
         }
     }

--- a/src/flatcollections-array/FlatArray/FlatArray.T.FlatList/FlatArray.FlatList.Impl.Implicit.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T.FlatList/FlatArray.FlatList.Impl.Implicit.cs
@@ -52,13 +52,13 @@ partial struct FlatArray<T>
                 return;
             }
 
-            var sourceSpan = length == items.Length
-                ? new ReadOnlySpan<T>(items)
-                : new ReadOnlySpan<T>(items, 0, length);
+            ReadOnlySpan<T> sourceSpan = length == items.Length
+                ? new(items)
+                : new(items, 0, length);
 
-            var destSpan = arrayIndex == default && length == array.Length
-                ? new Span<T>(array)
-                : new Span<T>(array, arrayIndex, length);
+            Span<T> destSpan = arrayIndex == default && length == array.Length
+                ? new(array)
+                : new(array, arrayIndex, length);
 
             sourceSpan.CopyTo(destSpan);
         }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
@@ -17,9 +17,9 @@ partial struct FlatArray<T>
         {
             Debug.Assert(length >= 0 && length <= array.Length);
 
-            var sourceSpan = length == array.Length
-                ? new ReadOnlySpan<T>(array)
-                : new ReadOnlySpan<T>(array, 0, length);
+            ReadOnlySpan<T> sourceSpan = length == array.Length
+                ? new(array)
+                : new(array, 0, length);
             return sourceSpan.ToArray();
         }
 
@@ -28,9 +28,9 @@ partial struct FlatArray<T>
         {
             Debug.Assert(InnerAllocHelper.IsSegmentWithinBounds(start, length, array.Length));
 
-            var sourceSpan = start == default && length == array.Length
-                ? new ReadOnlySpan<T>(array)
-                : new ReadOnlySpan<T>(array, start, length);
+            ReadOnlySpan<T> sourceSpan = start == default && length == array.Length
+                ? new(array)
+                : new(array, start, length);
             return sourceSpan.ToArray();
         }
 
@@ -40,17 +40,19 @@ partial struct FlatArray<T>
             Debug.Assert(length1 >= 0 && length1 <= array1.Length);
             Debug.Assert(length2 >= 0 && length2 <= array2.Length);
 
-            var sourceSpan1 = length1 == array1.Length
-                ? new ReadOnlySpan<T>(array1)
-                : new ReadOnlySpan<T>(array1, 0, length1);
+            ReadOnlySpan<T> sourceSpan1 = length1 == array1.Length
+                ? new(array1)
+                : new(array1, 0, length1);
 
-            var sourceSpan2 = length2 == array2.Length
-                ? new ReadOnlySpan<T>(array2)
-                : new ReadOnlySpan<T>(array2, 0, length2);
+            ReadOnlySpan<T> sourceSpan2 = length2 == array2.Length
+                ? new(array2)
+                : new(array2, 0, length2);
 
             var result = new T[length1 + length2];
+
             sourceSpan1.CopyTo(new Span<T>(result, 0, length1));
             sourceSpan2.CopyTo(new Span<T>(result, length1, length2));
+
             return result;
         }
     }

--- a/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
+++ b/src/flatcollections-array/FlatArray/FlatArray.T/InnerArrayHelper/FlatArray.InnerArrayHelper.cs
@@ -48,7 +48,7 @@ partial struct FlatArray<T>
                 ? new(array2)
                 : new(array2, 0, length2);
 
-            var result = new T[length1 + length2];
+            var result = new T[unchecked(length1 + length2)];
 
             sourceSpan1.CopyTo(new Span<T>(result, 0, length1));
             sourceSpan2.CopyTo(new Span<T>(result, length1, length2));

--- a/src/flatcollections-array/FlatArray/FlatArrayJsonConverterFactory/Factory.CreateConverter.cs
+++ b/src/flatcollections-array/FlatArray/FlatArrayJsonConverterFactory/Factory.CreateConverter.cs
@@ -20,7 +20,7 @@ partial class FlatArrayJsonConverterFactory
             type: typeof(FlatArray<>.JsonConverter).MakeGenericType(itemType),
             bindingAttr: BindingFlags.Instance | BindingFlags.Public,
             binder: null,
-            args: new object?[] { options },
+            args: [options],
             culture: null);
 
         Debug.Assert(converter is not null);


### PR DESCRIPTION
Minor refactor:
- `JsonConverterFactory.CreateConverter`: Use collection expressions for building `object` arg array from Json `options` param.
- Simplify syntax when initializing spans (use the shortened `new` constructor syntax)
- Explicitly use default `unchecked` when summing array lengths (both for clarity and to produce more appropriate exception when instantiating a too large array)